### PR TITLE
Feature/custom options and selector reset

### DIFF
--- a/src/Components/Select3.php
+++ b/src/Components/Select3.php
@@ -130,19 +130,16 @@ class Select3 extends Component
     #[On('select3:updated')]
     public function handleDependentUpdate(string $id, mixed $value, ?string $name = null): void
     {
-        // Handle internal dependencies
         if ($this->dependsOn === $id) {
-            $previousValue = $this->selectedValue; // Store the previous selection
+            $previousValue = $this->selectedValue;
             $this->parentValue = $value;
             $this->isDisabled = empty($value);
             $this->search = '';
             $this->options = [];
 
             if (! empty($value)) {
-                // Load options first
                 $this->loadOptions(true);
 
-                // Only clear selection if the previous value doesn't exist in new options
                 if ($previousValue && ! empty($this->options)) {
                     $valueExists = collect($this->options)->contains('value', $previousValue);
                     if (! $valueExists) {
@@ -162,8 +159,10 @@ class Select3 extends Component
     }
 
     #[On('select3:reset')]
-    public function handleReset(string $id): void
+    public function handleReset($data): void
     {
+        $id = is_array($data) ? $data['id'] : $data;
+        
         if ($this->id === $id) {
             $this->selectedValue = null;
             $this->search = '';

--- a/src/resources/views/select3.blade.php
+++ b/src/resources/views/select3.blade.php
@@ -18,6 +18,11 @@
         .select3-dropdown .keyboard-selected {
             background-color: rgba(var(--bs-primary-rgb), 0.15) !important;
         }
+        .select3-custom-option {
+            border-top: 1px dashed #ccc;
+            margin-top: 4px;
+            padding-top: 4px;
+        }
     </style>
 
     <!-- Hidden input for form submission -->
@@ -75,6 +80,22 @@
                 <div class="p-3 text-center text-muted">
                     {{ strlen($search) >= $minInputLength ? __('No results found') : __('Type to search...') }}
                 </div>
+                
+                <!-- Custom option when no results and allowCustomOption is enabled -->
+                @if($allowCustomOption && strlen($search) >= $minInputLength)
+                <div class="select3-custom-option">
+                    <button
+                        type="button"
+                        class="list-group-item list-group-item-action"
+                        :class="{ 'keyboard-selected': isHighlighted(0) }"
+                        wire:key="create-custom-option"
+                        @click="open = false; $wire.createCustomOption()"
+                        @mouseenter="highlightedIndex = 0"
+                    >
+                        <i class="fa fa-plus-circle me-1"></i> {{ $customOptionText }} "{{ $search }}"
+                    </button>
+                </div>
+                @endif
             @else
                 <div class="list-group list-group-flush">
                     @foreach ($options as $index => $option)
@@ -95,6 +116,22 @@
                             {{ $option['text'] }}
                         </button>
                     @endforeach
+                    
+                    <!-- Custom option when results exist and allowCustomOption is enabled -->
+                    @if($allowCustomOption && strlen($search) >= $minInputLength)
+                    <div class="select3-custom-option">
+                        <button
+                            type="button"
+                            class="list-group-item list-group-item-action"
+                            :class="{ 'keyboard-selected': isHighlighted({{ count($options) }}) }"
+                            wire:key="create-custom-option"
+                            @click="open = false; $wire.createCustomOption()"
+                            @mouseenter="highlightedIndex = {{ count($options) }}"
+                        >
+                            <i class="fa fa-plus-circle me-1"></i> {{ $customOptionText }} "{{ $search }}"
+                        </button>
+                    </div>
+                    @endif
                 </div>
             @endif
         </div>

--- a/src/resources/views/select3.blade.php
+++ b/src/resources/views/select3.blade.php
@@ -63,6 +63,7 @@
                     class="form-control form-control-sm"
                     placeholder="{{ __('Search...') }}"
                     wire:model.live.debounce.{{ $debounce }}ms="search"
+                    @keydown.enter.prevent="if($wire.allowCustomOption && $wire.search && !$wire.options.length) { $wire.createCustomOption(); open = false; }"
                     @click.stop
             >
         </div>


### PR DESCRIPTION
Added custom product creation capability with `allowCustomOption` property, fixed `handleReset` to handle both string and array inputs, and implemented Enter key support to create custom products when no search results exist.